### PR TITLE
Proofing and a11y first-pass

### DIFF
--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -46,7 +46,7 @@ export default function Layout({ children }: any) {
                                         target='_blank'
                                     >
                                         <div>
-                                            <i className='fa-brands fa-mastodon text-2xl'></i>
+                                            <i className='fa-brands fa-mastodon text-2xl' aria-hidden="true">&nbsp;</i>
                                         </div>
                                         <div>
                                             { data.user }@{ data.domain }
@@ -59,22 +59,24 @@ export default function Layout({ children }: any) {
                 </div>
                 <div>
                     Find us here:
-                    <div className='flex items-center flex-row gap-4'>
+                    <div className='flex items-start flex-col gap-4'>
                         <a
                             href='https://github.com/CyberFurz/furryfediverse-site'
-                            className='link text-6xl no-underline'
+                            className='link text-xl no-underline'
                             target='_blank'
                             rel='noreferrer'
                         >
-                            <i className='fa-brands fa-github'></i>
+                            <i className='fa-brands fa-github' aria-hidden="true">&nbsp;</i>
+                            GitHub
                         </a>
                         <a
                             rel='me noreferrer'
                             href='https://cyberfurz.social/@FurryFediverse'
-                            className='link text-6xl no-underline'
+                            className='link text-xl no-underline'
                             target='_blank'
                         >
-                            <i className='fa-brands fa-mastodon'></i>
+                            <i className='fa-brands fa-mastodon' aria-hidden="true">&nbsp;</i>
+                            Mastodon
                         </a>
                     </div>
                 </div>

--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -34,7 +34,7 @@ export default function Layout({ children }: any) {
             <footer className='footer py-6 px-4 sm:px-12 bg-neutral text-neutral-content flex justify-between items-center'>
                 <div>
                     <div className='flex flex-col gap-2'>
-                        <div>Maintened by:</div>
+                        <div>Maintained by:</div>
                         <div></div>
                         { maintainers.map(
                             (data: { user: string; domain: string }) => (

--- a/next.config.js
+++ b/next.config.js
@@ -2,4 +2,8 @@
 module.exports = {
   reactStrictMode: true,
   swcMinify: true,
+  i18n: {
+    locales: ["en"],
+    defaultLocale: "en",
+  }
 }

--- a/pages/api/instances/add.ts
+++ b/pages/api/instances/add.ts
@@ -67,11 +67,11 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
                 '@' +
                 instanceData.uri +
                 ' ' +
-                'Hi there someone is attempting to register your instance on FurryFediverse, if this is you. Please click this link to finish the registation: https://furryfediverse.org/api/instances/verify/' +
+                'Hi there someone is attempting to register your instance on FurryFediverse, if this is you. Please click this link to finish the registration: https://furryfediverse.org/api/instances/verify/' +
                 savedInstance.api_key
             res.status(200).json({
                 message:
-                    'Added instance successfully, your instance admin account needs to be verfied! Check your DMs!',
+                    'Added instance successfully, your instance admin account needs to be verified! Check your DMs!',
                 type: 'success',
             })
             mastoClient

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -112,9 +112,9 @@ const Home: NextPage = ({ general, niche }: any) => {
                                 target='_blank'
                                 rel='noreferrer'
                             >
-                                <i className='fa-brands fa-twitter'></i>
-                                <i className='ml-2 fa-solid fa-arrow-right'></i>{ ' ' }
-                                <i className='ml-2 fa-brands fa-mastodon'></i>
+                                <i className='fa-brands fa-twitter' aria-hidden="true"></i>
+                                <i className='ml-2 fa-solid fa-arrow-right' aria-hidden="true"></i>{ ' ' }
+                                <i className='ml-2 fa-brands fa-mastodon' aria-hidden="true"></i>
                                 <span className='ml-2'>Fedifinder</span>
                             </a>
                             <a
@@ -123,9 +123,9 @@ const Home: NextPage = ({ general, niche }: any) => {
                                 target='_blank'
                                 rel='noreferrer'
                             >
-                                <i className='fa-brands fa-twitter'></i>
-                                <i className='ml-2 fa-solid fa-arrow-right'></i>{ ' ' }
-                                <i className='ml-2 fa-brands fa-mastodon'></i>
+                                <i className='fa-brands fa-twitter' aria-hidden="true"></i>
+                                <i className='ml-2 fa-solid fa-arrow-right' aria-hidden="true"></i>{ ' ' }
+                                <i className='ml-2 fa-brands fa-mastodon' aria-hidden="true"></i>
                                 <span className='ml-2'>Twitodon</span>
                             </a>
                         </div>
@@ -137,7 +137,7 @@ const Home: NextPage = ({ general, niche }: any) => {
                                 target='_blank'
                                 rel='noreferrer'
                             >
-                                <i className='fa-brands fa-apple mr-2'></i>{ ' ' }
+                                <i className='fa-brands fa-apple mr-2' aria-hidden="true"></i>{ ' ' }
                                 Toot! (Paid)
                             </a>
                             <a
@@ -146,7 +146,7 @@ const Home: NextPage = ({ general, niche }: any) => {
                                 target='_blank'
                                 rel='noreferrer'
                             >
-                                <i className='fa-brands fa-apple mr-2'></i>{ ' ' }
+                                <i className='fa-brands fa-apple mr-2' aria-hidden="true"></i>{ ' ' }
                                 Ivory
                             </a>
                             <a
@@ -155,7 +155,7 @@ const Home: NextPage = ({ general, niche }: any) => {
                                 target='_blank'
                                 rel='noreferrer'
                             >
-                                <i className='fa-brands fa-apple mr-2'></i>{ ' ' }
+                                <i className='fa-brands fa-apple mr-2' aria-hidden="true"></i>{ ' ' }
                                 Ice Cubes
                             </a>
                             <a
@@ -164,7 +164,7 @@ const Home: NextPage = ({ general, niche }: any) => {
                                 target='_blank'
                                 rel='noreferrer'
                             >
-                                <i className='fa-brands fa-android mr-2'></i>{ ' ' }
+                                <i className='fa-brands fa-android mr-2' aria-hidden="true"></i>{ ' ' }
                                 Fedilab
                             </a>
                             <a
@@ -173,7 +173,7 @@ const Home: NextPage = ({ general, niche }: any) => {
                                 target='_blank'
                                 rel='noreferrer'
                             >
-                                <i className='fa-brands fa-android mr-2'></i>{ ' ' }
+                                <i className='fa-brands fa-android mr-2' aria-hidden="true"></i>{ ' ' }
                                 Tusky
                             </a>
                             <a
@@ -182,7 +182,7 @@ const Home: NextPage = ({ general, niche }: any) => {
                                 target='_blank'
                                 rel='noreferrer'
                             >
-                                <i className='fa-brands fa-android mr-2'></i>{ ' ' }
+                                <i className='fa-brands fa-android mr-2' aria-hidden="true"></i>{ ' ' }
                                 Megalodon
                             </a>
                         </div>
@@ -208,34 +208,27 @@ const Home: NextPage = ({ general, niche }: any) => {
                         </p>
                         <br />
                         <ul className='tabs w-full grid grid-cols-2'>
-                            <div
-                                className='tooltip tooltip-primary w-full'
+                            <li
+                                key={ 0 }
                                 data-tip='Instances open to furries of any kind with no specific topic'
+
+                                className={ `text-2xl tab tab-bordered h-fit w-full tooltip tooltip-primary w-full ${
+                                    0 === active && 'tab-active'
+                                }` }
+                                onClick={ () => setActive(0) }
                             >
-                                <li
-                                    key={ 0 }
-                                    className={ `text-2xl tab tab-bordered h-fit w-full ${
-                                        0 === active && 'tab-active'
-                                    }` }
-                                    onClick={ () => setActive(0) }
-                                >
-                                    General Instances
-                                </li>
-                            </div>
-                            <div
-                                className='tooltip tooltip-primary w-full'
+                                General Instances
+                            </li>
+                            <li
+                                key={ 1 }
                                 data-tip='Furry friendly instances with a focus on one or more topics'
+                                className={ `text-2xl tab tab-bordered h-fit w-full tooltip tooltip-primary w-full ${
+                                    1 === active && 'tab-active'
+                                }` }
+                                onClick={ () => setActive(1) }
                             >
-                                <li
-                                    key={ 1 }
-                                    className={ `text-2xl tab tab-bordered h-fit w-full ${
-                                        1 === active && 'tab-active'
-                                    }` }
-                                    onClick={ () => setActive(1) }
-                                >
-                                    Focused Instances
-                                </li>
-                            </div>
+                                Focused Instances
+                            </li>
                         </ul>
                         <br />
                         <div className=''>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -129,7 +129,7 @@ const Home: NextPage = ({ general, niche }: any) => {
                                 <span className='ml-2'>Twitodon</span>
                             </a>
                         </div>
-                        <p className='font-bold py-4'>Recomended Apps</p>
+                        <p className='font-bold py-4'>Recommended Apps</p>
                         <div className='px-2 flex flex-wrap gap-2'>
                             <a
                                 href='https://apps.apple.com/us/app/toot/id1229021451'
@@ -472,7 +472,7 @@ const Home: NextPage = ({ general, niche }: any) => {
                                     href='/report-instance'
                                     className='underline'
                                 >
-                                    Report Instace
+                                    Report Instance
                                 </Link>
                             </p>
                         </div>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,3 +1,15 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+a[target="_blank"]::after { /* Provides a basic notice to screen-reader users that these links will open a new window */
+    position: absolute;
+    height: 1px;
+    width: 1px;
+    clip: rect(1px 1px 1px 1px);
+    clip: rect(1px,1px,1px,1px);
+    clip-path: polygon(0px 0px, 0px 0px, 0px 0px);
+    -webkit-clip-path: polygon(0px 0px, 0px 0px, 0px 0px);
+    overflow: hidden !important;
+    content: "opens in new window"
+}


### PR DESCRIPTION
Fixes some tiny spelling mistakes in the frontend, as well as resolving some accessibility issues.

A11Y issues fixed (error codes from [Checka11y.css](https://github.com/jackdomleo7/Checka11y.css)):
- E0006 - next.config.js:5 - The lang attribute is either not present on the `<html>` element or has an empty value.
  - Added i18n block to define the locale as "en"

- E0011 - pages\index.ts:210 & pages\index,ts:225 - The highlighted element has been detected inside of a `<ul>` or an `<ol>` and is in the incorrect place.
  - Removed extra `div` elements used for tooltips on the instance list and added the classes to the clickable `li` elements instead
  
- W0006 - The highlighted `<a>` has been detected to contain target="_blank", which means the link will open in a new tab.
  -  Added a CSS rule to append a screen-reader only element to the end of `a` elements with a target of `_blank` which tells the user that the link opens in a new window/tab
  
- Additionally add the `aria-hidden=true` attributes to the FontAwesome icons inside `a` elements to improve screen-reader flow.