### PR TITLE
Invert misskey registration value

### DIFF
--- a/pages/api/instances/add.ts
+++ b/pages/api/instances/add.ts
@@ -63,7 +63,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
                     user_count: misskeyStatsData.originalUsersCount,
                     status_count: misskeyStatsData.notesCount,
                     instance_contact: 'null',
-                    registrations: misskeyMetaData.disableRegistration,
+                    registrations: misskeyMetaData.disableRegistration === false,
                     approval_required: false,
                 }
                 return parsedMasterData

--- a/pages/api/instances/cache.ts
+++ b/pages/api/instances/cache.ts
@@ -52,7 +52,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
                     user_count: misskeyStatsData.originalUsersCount,
                     status_count: misskeyStatsData.notesCount,
                     instance_contact: 'null',
-                    registrations: misskeyMetaData.disableRegistration,
+                    registrations: misskeyMetaData.disableRegistration === false,
                     approval_required: false,
                 }
                 return parsedMasterData


### PR DESCRIPTION
The registrations field is currently inverted for misskey-based instances since misskey reports whether registrations is disabled rather than enabled like mastodon does.